### PR TITLE
Get thruster chamber quality from thruster

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -55,11 +55,9 @@ local function on_entity_died(event)
                 storage.fusionthruster.assem[assem_unit_number] = nil
             end
 
-
             storage.fusionthruster.entities[entity.unit_number] = nil
             storage.fusionthruster.unit[entity.unit_number] = nil
         else 
-            local pos = entity.position.x .. " " .. entity.position.y
             local entities = entity.surface.find_entities({{entity.position.x - 3, entity.position.y - 3},{entity.position.x + 3, entity.position.y + 3}})
 
             for i = 1, #entities do

--- a/control.lua
+++ b/control.lua
@@ -24,6 +24,7 @@ local function on_built(event)
             name = "fusionthruster-thruster-chamber",
             position = assem_pos,
             force = entity.force,
+            quality = entity.quality,
             direction = entity.direction,
             destructible = false
         }

--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,3 @@
-
 local function on_init()
     storage.fusionthruster = storage.fusionthruster or {}
     storage.fusionthruster.entities = storage.fusionthruster.entities or {}
@@ -28,9 +27,9 @@ local function on_built(event)
             direction = entity.direction,
             destructible = false
         }
-        storage.fusionthruster.assem[pos .. "_1"] = assem
+        storage.fusionthruster.assem[assem.unit_number] = assem
 
-        storage.fusionthruster.entities[pos] = entity
+        storage.fusionthruster.entities[entity.unit_number] = entity
 
         if entity.unit_number then
             storage.fusionthruster.unit[entity.unit_number] = {
@@ -48,22 +47,31 @@ local function on_entity_died(event)
         return
     end
 
-
-    local pos = entity.position.x .. " " .. entity.position.y
-
-
-    if storage.fusionthruster.entities[pos] ~= nil then
-
-        if storage.fusionthruster.assem[pos .. "_1"] then
-            storage.fusionthruster.assem[pos .. "_1"].destroy()
-            storage.fusionthruster.assem[pos .. "_1"] = nil
-        end
+    if entity.unit_number then
+        if storage.fusionthruster.entities[entity.unit_number] ~= nil then
+            local assem_unit_number = storage.fusionthruster.unit[entity.unit_number].assem
+            if storage.fusionthruster.assem[assem_unit_number] then
+                storage.fusionthruster.assem[assem_unit_number].destroy()
+                storage.fusionthruster.assem[assem_unit_number] = nil
+            end
 
 
-        storage.fusionthruster.entities[pos] = nil
-
-        if entity.unit_number then
+            storage.fusionthruster.entities[entity.unit_number] = nil
             storage.fusionthruster.unit[entity.unit_number] = nil
+        else 
+            local pos = entity.position.x .. " " .. entity.position.y
+            local entities = entity.surface.find_entities({{entity.position.x - 3, entity.position.y - 3},{entity.position.x + 3, entity.position.y + 3}})
+
+            for i = 1, #entities do
+                local assem_unit_number = storage.fusionthruster.unit[entity.unit_number].assem
+                if entities[i].unit_number == assem_unit_number then
+                    entities[i].destroy()
+                    if entity.unit_number then
+                        storage.fusionthruster.unit[entity.unit_number] = nil
+                    end
+                    break
+                end
+            end
         end
     end
 end
@@ -83,4 +91,4 @@ script.on_event(defines.events.on_entity_died, on_entity_died, filter)
 script.on_event(defines.events.script_raised_destroy, on_entity_died, filter)
 script.on_event(defines.events.on_robot_pre_mined, on_entity_died, filter)
 script.on_event(defines.events.on_space_platform_mined_entity, on_entity_died, filter)
-script.on_event(defines.events.on_pre_player_mined_item, on_entity_died, filter)      
+script.on_event(defines.events.on_pre_player_mined_item, on_entity_died, filter) 


### PR DESCRIPTION
When instantiating the thruster chamber, copy its quality value from the thruster entity.

Tested it and seems to work. No longer slowly bleeds fluorikutone due to input/output inbalance.