### PR TITLE
Fusion Thrusters respect neighbor bonus

### DIFF
--- a/prototypes/entity/fusionthruster.lua
+++ b/prototypes/entity/fusionthruster.lua
@@ -296,18 +296,6 @@ local thruster_chamber = {
   flags = { "placeable-neutral", "placeable-player", "player-creation", "get-by-unit-number", "not-on-map", "not-in-made-in", "placeable-off-grid" },
   fluid_boxes =
   {
-    {
-      filter = "fusion-plasma",
-      volume = 10,
-      production_type = "input",
-      draw_only_when_connected = true,
-      pipe_connections =
-      {
-        {flow_direction = "input-output", connection_type = "normal", connection_category = "fusion-plasma", direction = defines.direction.west, position = {-1, 0}},
-        {flow_direction = "input-output", connection_type = "normal", connection_category = "fusion-plasma", direction = defines.direction.east, position = { 1, 0}}
-      }
-    },
-
     { 
       pipe_connections = 
       { 
@@ -317,16 +305,6 @@ local thruster_chamber = {
       volume = 180,
       filter = "thruster-fusion-plasma", 
       hide_connection_info = true
-    },
-
-    { 
-      pipe_connections = 
-      { 
-        { direction = defines.direction.north, flow_direction = "output", position = { 0, -0.28 } } 
-      }, 
-      production_type = "output", 
-      filter = "fluoroketone-hot", 
-      volume = 10
     }
   }
 }
@@ -357,12 +335,10 @@ local recipe_thruster_fusion_plasma = {
   category = "thruster-fusion-plasma",
   ingredients = 
   {
-    { type = "fluid", name = "fusion-plasma", amount = 4 }
   },
   results = 
   {
-    { type = "fluid", name = "thruster-fusion-plasma", amount = settings.startup["fusionthruster-thruster-chamber-conversion-value"].value },
-    { type = "fluid", name = "fluoroketone-hot", amount = 4 }
+    { type = "fluid", name = "thruster-fusion-plasma", amount = settings.startup["fusionthruster-thruster-chamber-conversion-value"].value }
   }
 }
 

--- a/settings.lua
+++ b/settings.lua
@@ -52,7 +52,7 @@ data:extend({
     type = "string-setting",
     name = "fusionthruster-thruster-chamber-energy-value",
     setting_type = "startup",
-    default_value = "10MW",
+    default_value = "50MW",
     order = "c"
   },
   {


### PR DESCRIPTION
I spent about a week learning a lot about the Fluid energy source prototype and I can't find a way to make the fusion thruster burn the fusion plasma while caring about the plasma's temperature without also introducing a slow leak in the plasma/fluoroketone loop, so instead we can just set the hidden assembler to use a default of 50MW of power and produce the "fusion thruster plasma" for "free".